### PR TITLE
fix(node, way, relation, changeset, osmChange): removed OsmTypes enum

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,13 +1,7 @@
-enum OsmTypes {
-  NODE = 'node',
-  WAY = 'way',
-  RELATION = 'relation',
-  OSMCHANGE = 'osmchange',
-  CHANGESET = 'changeset',
-}
+type OsmElementType = 'node' | 'way' | 'relation';
 
 interface BaseElement {
-  type: OsmTypes.NODE | OsmTypes.WAY | OsmTypes.RELATION;
+  type: OsmElementType;
   id: number;
   timestamp?: string;
   version?: number;
@@ -17,18 +11,18 @@ interface BaseElement {
 }
 
 interface OsmNode extends BaseElement {
-  type: OsmTypes.NODE;
+  type: 'node';
   lat: number;
   lon: number;
 }
 
 interface OsmWay extends BaseElement {
-  type: OsmTypes.WAY;
+  type: 'way';
   nodes: OsmNode[];
 }
 
 interface OsmApiWay extends BaseElement {
-  type: OsmTypes.WAY;
+  type: 'way';
   nodes: number[];
 }
 
@@ -37,19 +31,19 @@ type Member = BaseElement & {
 };
 
 interface OsmRelation extends BaseElement {
-  type: OsmTypes.RELATION;
+  type: 'relation';
   members?: Member[];
 }
 
 interface Changeset {
-  type: OsmTypes.CHANGESET;
+  type: 'changeset';
   version?: string;
   generator?: string;
   tags?: { [key: string]: string };
 }
 
 interface OsmChange {
-  type: OsmTypes.OSMCHANGE;
+  type: 'osmchange';
   version?: string;
   generator?: string;
   create?: BaseElement[];
@@ -57,4 +51,4 @@ interface OsmChange {
   delete?: BaseElement[];
 }
 
-export { BaseElement, OsmNode, OsmWay, OsmApiWay, OsmRelation, Changeset, OsmChange, Member, OsmTypes };
+export { BaseElement, OsmNode, OsmWay, OsmApiWay, OsmRelation, Changeset, OsmChange, Member, OsmElementType };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,8 +1,8 @@
-import { BaseElement, OsmNode, OsmWay, OsmApiWay, OsmTypes } from '..';
+import { BaseElement, OsmNode, OsmWay, OsmApiWay } from '..';
 
-const isWay = (element: BaseElement): element is OsmApiWay => element.type === OsmTypes.WAY;
+const isWay = (element: BaseElement): element is OsmApiWay => element.type === 'way';
 
-const isNode = (element: BaseElement): element is OsmNode => element.type === OsmTypes.NODE;
+const isNode = (element: BaseElement): element is OsmNode => element.type === 'node';
 
 /**
  * Parses the response of the /api/0.6/way/#id/full from OsmApiWay representation to OsmWay one.

--- a/tests/util.spec.ts
+++ b/tests/util.spec.ts
@@ -1,8 +1,8 @@
-import { OsmApiWay, OsmNode, OsmWay, OsmTypes } from '../src';
+import { OsmApiWay, OsmNode, OsmWay } from '../src';
 import { parseOsmWayApi } from '../src/util';
 
 const osmApiWay: OsmApiWay = {
-  type: OsmTypes.WAY,
+  type: 'way',
   id: 1,
   timestamp: '2019-02-14T07:33:10Z',
   version: 1,
@@ -12,7 +12,7 @@ const osmApiWay: OsmApiWay = {
 };
 const osmNodes = osmApiWay.nodes.map((nodeId) => {
   const osmNode: OsmNode = {
-    type: OsmTypes.NODE,
+    type: 'node',
     id: nodeId,
     lat: 35,
     lon: 36,


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix        | ✔                                                                         |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation  | ✖                                                                         |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Closes #21

`node`, `way` and `relation` are now represented in a type of closed strings, `changeset` and `osmChange` "type" key returned to be represented as a simple string
